### PR TITLE
Fix small typo

### DIFF
--- a/content/faq.md
+++ b/content/faq.md
@@ -33,6 +33,6 @@ No, it cannot. Darling requires a real Linux kernel.
 
 **Will you support applications for iPhone/iPod/iPad?**
 
-The intention is to support the ARM platform on the lowest levels (the dynamic loader an the Objective-C runtime). Rewriting the frameworks used on iOS is a whole different story, though. See [iOS Support Information](/for-developers/ios-support-information).
+The intention is to support the ARM platform on the lowest levels (the dynamic loader and the Objective-C runtime). Rewriting the frameworks used on iOS is a whole different story, though. See [iOS Support Information](/for-developers/ios-support-information).
 
 


### PR DESCRIPTION
Reading this I belive it should be "and" rather than "an", so here's a pull request to fix that.