### PR TITLE
Tweak the terminal box styles to be more readable

### DIFF
--- a/themes/darlinghq/static/css/style.css
+++ b/themes/darlinghq/static/css/style.css
@@ -126,7 +126,7 @@ code, pre {
 }
 
 pre.terminal-box {
-	background: black;
+	background: rgb(22, 22, 22);
 	max-width: 400px;
 	border-radius: 10px;
 	margin: 40px auto;
@@ -134,11 +134,11 @@ pre.terminal-box {
 	color: white;
 	font-size: 20px;
 	font-weight: bold;
-	box-shadow: 0px 0px 20px 5px black;
+	box-shadow: 0px 2px 4px 0px black;
 }
 
 pre.terminal-box .cwd {
-	color: blue;
+	color: rgb(60, 90, 250);
 }
 
 pre.terminal-box .prompt {
@@ -146,7 +146,7 @@ pre.terminal-box .prompt {
 }
 
 pre.terminal-box .command {
-	color: #9c27b0;
+	color: rgb(170, 60, 170);
 }
 
 .intro {


### PR DESCRIPTION
The box shadow is now offset to give the terminal a more "well-defined" appearance. See [tip 3 in this article](https://medium.com/refactoring-ui/7-practical-tips-for-cheating-at-design-40c736799886) for details.

## Preview

### Before

![image](https://user-images.githubusercontent.com/180032/61745456-e845c980-ad99-11e9-917a-359a1ad109b2.png)

### After

![image](https://user-images.githubusercontent.com/180032/61745424-d9f7ad80-ad99-11e9-8324-d79d2f9f744b.png)