### PR TITLE
Fix the navbar on mobile

### DIFF
--- a/themes/darlinghq/static/css/style.css
+++ b/themes/darlinghq/static/css/style.css
@@ -224,11 +224,9 @@ ul.faq a {
 	nav ul li a {
 		padding: 5px 20px;
 	}
-	nav:hover {
+	nav {
 		background: rgb(135, 167, 255);
-	}
-	nav:not(:hover) ul {
-		display: none;
+                width: 100%;
 	}
 	nav::before {
 		display: block;


### PR DESCRIPTION
Before, the navbar would show up on hover on mobile. It seems like this was not tested properly because you can't hover on mobile. It disappears almost instantly, making it very hard to click any of the links. This makes the navbar show up permanently on mobile. I could have made the button toggle the bar, but this works fine for now.

Before:

![image](https://user-images.githubusercontent.com/13787163/71841187-bc53a180-30b6-11ea-8898-e245c584f4c8.png)

After:

![image](https://user-images.githubusercontent.com/13787163/71841208-cb3a5400-30b6-11ea-8ca9-e8e4ad64f022.png)
