### PR TITLE
Fix invalid wiki.darlinghq.org links

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -71,6 +71,6 @@ type = "index"
     </li>
     <li>
         <p class="heading">How do I contribute?</p> 
-        <p>Start by reading the <a href="https://wiki.darlinghq.org">documentation</a> and <a href="http://blog.darlinghq.org">our blog</a> to get familiar with Darling internals. Then, come and join us <a href="https://github.com/darlinghq/darling">on GitHub</a>. It's great if you have experience in developing for macOS or iOS, but it's absolutely not required to start contributing.</p>
+        <p>Start by reading the <a href="https://docs.darlinghq.org">documentation</a> and <a href="http://blog.darlinghq.org">our blog</a> to get familiar with Darling internals. Then, come and join us <a href="https://github.com/darlinghq/darling">on GitHub</a>. It's great if you have experience in developing for macOS or iOS, but it's absolutely not required to start contributing.</p>
     </li>
 </ul>

--- a/content/introduction.md
+++ b/content/introduction.md
@@ -10,9 +10,9 @@ The aim of the Darling project is to provide the following:
 * runtime, system library and framework reimplementations to enable OS X executables to function;
 * additional tools to assist with application installation.
 
-## Wiki
+## Docs
 
-This is just an introductory article. You can always learn more by visiting the [wiki](https://wiki.darlinghq.org/).
+This is just an introductory article. You can always learn more by visiting the [documentation](https://docs.darlinghq.org/).
 
 ## Running Applications
 

--- a/content/source-code.md
+++ b/content/source-code.md
@@ -11,9 +11,9 @@ Like OS X, Darling includes **MANY** third party components. These are typically
 git clone --recursive https://github.com/darlinghq/darling.git
 ```
 
-See the [build instructions](https://wiki.darlinghq.org/build_instructions).
+See the [build instructions](https://docs.darlinghq.org/build-instructions.html).
 
-### darling-dmg <a href="http://teamcity.dolezel.info/viewType.html?buildTypeId=DarlingDmg_Build&#038;guest=1"><img src="http://teamcity.dolezel.info/app/rest/builds/buildType:(id:DarlingDmg_Build)/statusIcon"/></a>
+### darling-dmg
 
 darling-dmg is a component of Darling used for mounting DMG disk images (with an HFS+ filesystem) through FUSE. It can be used standalone, without the rest of Darling, or even as a library in your own project.
 


### PR DESCRIPTION
I stumbled on one on the homepage and then found a couple more via Github search.